### PR TITLE
Updated Utf8JsonHelpers with new methods for extracting strongly-typed values from JSON tokens

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,7 @@
   - [Custom JsonSerializerOptions](#custom-jsonserializeroptions)
   - [Processing Large Collections](#processing-large-collections)
   - [Exception Handling](#exception-handling)
+- [Value Methods](#utf8jsonhelpers-extension-methods)
 - [How It Works](#how-it-works)
 - [Samples](#samples)
 - [v1.3.0 Performance Graphs](#v130-performance-graphs)
@@ -184,6 +185,93 @@ catch (OperationCanceledException)
 }
 ```
 
+## Value Methods
+
+The `Utf8JsonHelpers` class provides comprehensive extension methods to extract strongly-typed values from JSON tokens. These methods follow the standard .NET patterns and offer both safe (Try*) and direct (Get*) access patterns.
+
+### String & Copy Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `GetString()` | `string?` | Gets the string value, returns null for JSON null tokens |
+| `CopyString(Span<byte>)` | `int` | Copies UTF-8 bytes to destination span, throws if buffer too small |
+| `CopyString(Span<char>)` | `int` | Copies transcoded UTF-16 chars to destination span, throws if buffer too small |
+
+### Boolean Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `GetBoolean()` | `bool?` | Gets the boolean value (true/false), returns null for non-boolean tokens |
+
+### Numeric Methods - Byte Types
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `GetByte()` | `byte` | Gets byte value (0-255), returns 0 on failure |
+| `TryGetByte(out byte?)` | `bool` | Attempts to get byte value, returns success status |
+| `GetSByte()` | `sbyte` | Gets signed byte value (-128 to 127), returns 0 on failure |
+| `TryGetSByte(out sbyte?)` | `bool` | Attempts to get signed byte value, returns success status |
+| `GetUByte()` | `uint` | Gets unsigned byte value, returns 0 on failure |
+| `TryGetUByte(out uint?)` | `bool` | Attempts to get unsigned byte value, returns success status |
+
+### Numeric Methods - Integer Types
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `GetInt16()` | `short` | Gets 16-bit signed integer (-32,768 to 32,767), returns 0 on failure |
+| `TryGetInt16(out short?)` | `bool` | Attempts to get 16-bit signed integer, returns success status |
+| `GetUInt16()` | `uint` | Gets 16-bit unsigned integer (0 to 65,535), returns 0 on failure |
+| `TryGetUInt16(out uint?)` | `bool` | Attempts to get 16-bit unsigned integer, returns success status |
+| `GetInt32()` | `int` | Gets 32-bit signed integer, returns 0 on failure |
+| `TryGetInt32(out int?)` | `bool` | Attempts to get 32-bit signed integer, returns success status |
+| `GetUInt32()` | `uint` | Gets 32-bit unsigned integer, returns 0 on failure |
+| `TryGetUInt32(out uint?)` | `bool` | Attempts to get 32-bit unsigned integer, returns success status |
+| `GetInt64()` | `long` | Gets 64-bit signed integer, returns 0 on failure |
+| `TryGetInt64(out long?)` | `bool` | Attempts to get 64-bit signed integer, returns success status |
+| `GetUInt64()` | `ulong` | Gets 64-bit unsigned integer, returns 0 on failure |
+| `TryGetUInt64(out ulong?)` | `bool` | Attempts to get 64-bit unsigned integer, returns success status |
+
+### Numeric Methods - Floating Point Types
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `GetSingle()` | `float` | Gets single-precision floating-point number, returns 0 on failure |
+| `TryGetSingle(out float?)` | `bool` | Attempts to get single-precision floating-point number, returns success status |
+| `GetDouble()` | `double` | Gets double-precision floating-point number, returns 0 on failure |
+| `TryGetDouble(out double?)` | `bool` | Attempts to get double-precision floating-point number, returns success status |
+| `GetDecimal()` | `decimal` | Gets decimal value, returns 0 on failure |
+| `TryGetDecimal(out decimal?)` | `bool` | Attempts to get decimal value, returns success status |
+
+### Date/Time Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `GetDateTime()` | `DateTime` | Gets DateTime value, returns default on failure |
+| `TryGetDateTime(out DateTime?)` | `bool` | Attempts to get DateTime value, returns success status |
+| `GetDateTimeOffset()` | `DateTimeOffset` | Gets DateTimeOffset value, returns default on failure |
+| `TryGetDateTimeOffset(out DateTimeOffset?)` | `bool` | Attempts to get DateTimeOffset value, returns success status |
+
+### GUID Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `GetGuid()` | `Guid` | Gets Guid value, returns Empty on failure |
+| `TryGetGuid(out Guid?)` | `bool` | Attempts to get Guid value, returns success status |
+
+### Base64 Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `GetBytesFromBase64()` | `byte[]?` | Decodes Base64 string to bytes, throws FormatException on failure |
+| `TryGetBytesFromBase64(out byte[]?)` | `bool` | Attempts to decode Base64 string, returns success status |
+
+### Value Extraction Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `GetValue()` | `object?` | Gets typed value based on TokenType (string, number, bool, null) |
+| `GetNumber()` | `object?` | Parses number token to best-fit numeric type (Int16, Int32, Int64, Double) |
+
 ## How It Works
 
 For a detailed explanation of the internal architecture, performance optimizations, and streaming mechanisms, see our comprehensive [How It Works](HOW_IT_WORKS.md) documentation, with mermaid diagrams.
@@ -260,7 +348,13 @@ If you find this library useful, please consider [buying me a coffee ☕](https:
 
 ## History
 
-### v2.0.0 - November 2025
+### v2.1.0 - 19 November 2025
+
+- Added new Value methods: CopyString (performant UTF8 & UTF16), GetSByte, TryGetSByte, GetBytesFromBase64, TryGetBytesFromBase64
+- Updated readme with tables of all Value converter methods
+- Added test coverage for new Value methods
+
+### v2.0.0 - 17 November 2025
 
 - Added support for .Net 10
 - Removed support for .Net 7

--- a/src/System.Text.Json.Stream.Tests/Utf8JsonHelpersTests.cs
+++ b/src/System.Text.Json.Stream.Tests/Utf8JsonHelpersTests.cs
@@ -1,0 +1,681 @@
+using System.Text.Json;
+using System.Text.Json.Stream;
+using FluentAssertions;
+using Xunit;
+using JsonReader = System.Text.Json.Stream.Utf8JsonAsyncStreamReader;
+
+namespace UnitTests.Tests.Readers.System.Text.Json;
+
+/// <summary>
+/// Comprehensive tests for the <see cref="System.Text.Json.Stream.Utf8JsonHelpers"/> extension methods.
+/// </summary>
+[Collection("Sequential")]
+public class Utf8JsonHelpersTests
+{
+    private static readonly DateTime testDateTime = new(2022, 09, 01, 11, 12, 13);
+    private static readonly DateTimeOffset testDateTimeOffset = new(testDateTime, new TimeSpan(0, 30, 0));
+    private static readonly Guid testGuid = Guid.NewGuid();
+
+    #region String Methods
+
+    [Fact]
+    async Task GetString_WithValidString_ReturnsString()
+    {
+        // Arrange
+        var json = @"{""Name"": ""John""}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Name"
+        await reader.ReadAsync(); // "John"
+
+        // Assert
+        reader.GetString().Should().Be("John");
+    }
+
+    [Fact]
+    async Task GetString_WithNullValue_ReturnsNull()
+    {
+        // Arrange
+        var json = @"{""Name"": null}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Name"
+        await reader.ReadAsync(); // null
+
+        // Assert
+        reader.GetString().Should().BeNull();
+    }
+
+    [Fact]
+    async Task CopyString_WithByteSpan_CopiesCorrectly()
+    {
+        // Arrange
+        var json = @"{""Value"": ""Hello""}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+        byte[] buffer = new byte[20];
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Value"
+        await reader.ReadAsync(); // "Hello"
+        int bytesWritten = reader.CopyString(new Span<byte>(buffer));
+
+        // Assert
+        bytesWritten.Should().Be(5);
+        Encoding.UTF8.GetString(buffer, 0, bytesWritten).Should().Be("Hello");
+    }
+
+    [Fact]
+    async Task CopyString_WithCharSpan_CopiesCorrectly()
+    {
+        // Arrange
+        var json = @"{""Value"": ""World""}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+        char[] buffer = new char[20];
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Value"
+        await reader.ReadAsync(); // "World"
+        int charsWritten = reader.CopyString(new Span<char>(buffer));
+
+        // Assert
+        charsWritten.Should().Be(5);
+        new string(buffer, 0, charsWritten).Should().Be("World");
+    }
+
+    [Fact]
+    async Task CopyString_WithByteSpan_ThrowsWhenBufferTooSmall()
+    {
+        // Arrange
+        var json = @"{""Value"": ""HelloWorld""}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+        byte[] buffer = new byte[2]; // Too small
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Value"
+        await reader.ReadAsync(); // "HelloWorld"
+
+        // Assert
+        var action = () => reader.CopyString(new Span<byte>(buffer));
+        action.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    async Task CopyString_WithCharSpan_ThrowsWhenBufferTooSmall()
+    {
+        // Arrange
+        var json = @"{""Value"": ""HelloWorld""}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+        char[] buffer = new char[2]; // Too small
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Value"
+        await reader.ReadAsync(); // "HelloWorld"
+
+        // Assert
+        var action = () => reader.CopyString(new Span<char>(buffer));
+        action.Should().Throw<ArgumentException>();
+    }
+
+    #endregion
+
+    #region Boolean Methods
+
+    [Fact]
+    async Task GetBoolean_WithTrue_ReturnsTrue()
+    {
+        // Arrange
+        var json = @"{""Active"": true}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Active"
+        await reader.ReadAsync(); // true
+
+        // Assert
+        reader.GetBoolean().Should().Be(true);
+    }
+
+    [Fact]
+    async Task GetBoolean_WithFalse_ReturnsFalse()
+    {
+        // Arrange
+        var json = @"{""Active"": false}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Active"
+        await reader.ReadAsync(); // false
+
+        // Assert
+        reader.GetBoolean().Should().Be(false);
+    }
+
+    #endregion
+
+    #region Byte Methods
+
+    [Fact]
+    async Task GetByte_WithValidByte_ReturnsByte()
+    {
+        // Arrange
+        var json = @"{""Value"": 255}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Value"
+        await reader.ReadAsync(); // 255
+
+        // Assert
+        reader.GetByte().Should().Be(255);
+    }
+
+    [Fact]
+    async Task TryGetByte_WithValidByte_ReturnsTrue()
+    {
+        // Arrange
+        var json = @"{""Value"": 128}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Value"
+        await reader.ReadAsync(); // 128
+        bool result = reader.TryGetByte(out byte? value);
+
+        // Assert
+        result.Should().BeTrue();
+        value.Should().Be(128);
+    }
+
+    [Fact]
+    async Task GetUByte_WithValidValue_ReturnsUByte()
+    {
+        // Arrange
+        var json = @"{""Value"": 200}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Value"
+        await reader.ReadAsync(); // 200
+
+        // Assert
+        reader.GetUByte().Should().Be(200);
+    }
+
+    [Fact]
+    async Task TryGetUByte_WithValidValue_ReturnsTrue()
+    {
+        // Arrange
+        var json = @"{""Value"": 100}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Value"
+        await reader.ReadAsync(); // 100
+        bool result = reader.TryGetUByte(out uint? value);
+
+        // Assert
+        result.Should().BeTrue();
+        value.Should().Be(100);
+    }
+
+    [Fact]
+    async Task GetSByte_WithValidValue_ReturnsSByte()
+    {
+        // Arrange
+        var json = @"{""Value"": -50}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Value"
+        await reader.ReadAsync(); // -50
+
+        // Assert
+        reader.GetSByte().Should().Be(-50);
+    }
+
+    [Fact]
+    async Task TryGetSByte_WithValidValue_ReturnsTrue()
+    {
+        // Arrange
+        var json = @"{""Value"": 75}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Value"
+        await reader.ReadAsync(); // 75
+        bool result = reader.TryGetSByte(out sbyte? value);
+
+        // Assert
+        result.Should().BeTrue();
+        value.Should().Be(75);
+    }
+
+    #endregion
+
+    #region Integer Methods (Int16, Int32, Int64, UInt16, UInt32, UInt64)
+
+    [Fact]
+    async Task GetInt16_WithValidValue_ReturnsInt16()
+    {
+        // Arrange
+        var json = @"{""Value"": 32000}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Value"
+        await reader.ReadAsync(); // 32000
+
+        // Assert
+        reader.GetInt16().Should().Be(32000);
+    }
+
+    [Fact]
+    async Task GetInt32_WithValidValue_ReturnsInt32()
+    {
+        // Arrange
+        var json = @"{""Value"": 2147483647}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Value"
+        await reader.ReadAsync(); // 2147483647
+
+        // Assert
+        reader.GetInt32().Should().Be(2147483647);
+    }
+
+    [Fact]
+    async Task GetInt64_WithValidValue_ReturnsInt64()
+    {
+        // Arrange
+        var json = @"{""Value"": 9223372036854775807}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Value"
+        await reader.ReadAsync(); // 9223372036854775807
+
+        // Assert
+        reader.GetInt64().Should().Be(9223372036854775807);
+    }
+
+    [Fact]
+    async Task GetUInt16_WithValidValue_ReturnsUInt16()
+    {
+        // Arrange
+        var json = @"{""Value"": 65000}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Value"
+        await reader.ReadAsync(); // 65000
+
+        // Assert
+        reader.GetUInt16().Should().Be(65000);
+    }
+
+    [Fact]
+    async Task GetUInt32_WithValidValue_ReturnsUInt32()
+    {
+        // Arrange
+        var json = @"{""Value"": 4294967295}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Value"
+        await reader.ReadAsync(); // 4294967295
+
+        // Assert
+        reader.GetUInt32().Should().Be(4294967295);
+    }
+
+    [Fact]
+    async Task GetUInt64_WithValidValue_ReturnsUInt64()
+    {
+        // Arrange
+        var json = @"{""Value"": 18446744073709551615}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Value"
+        await reader.ReadAsync(); // 18446744073709551615
+
+        // Assert
+        reader.GetUInt64().Should().Be(18446744073709551615);
+    }
+
+    #endregion
+
+    #region Floating Point Methods
+
+    [Fact]
+    async Task GetSingle_WithValidValue_ReturnsSingle()
+    {
+        // Arrange
+        var json = @"{""Value"": 123.45}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Value"
+        await reader.ReadAsync(); // 123.45
+
+        // Assert
+        reader.GetSingle().Should().BeApproximately(123.45f, 0.01f);
+    }
+
+    [Fact]
+    async Task GetDouble_WithValidValue_ReturnsDouble()
+    {
+        // Arrange
+        var json = @"{""Value"": 123456.789}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Value"
+        await reader.ReadAsync(); // 123456.789
+
+        // Assert
+        reader.GetDouble().Should().BeApproximately(123456.789, 0.01);
+    }
+
+    #endregion
+
+    #region Decimal Methods
+
+    [Fact]
+    async Task GetDecimal_WithValidValue_ReturnsDecimal()
+    {
+        // Arrange
+        var json = @"{""Value"": 12345.67}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Value"
+        await reader.ReadAsync(); // 12345.67
+
+        // Assert
+        reader.GetDecimal().Should().Be(12345.67m);
+    }
+
+    [Fact]
+    async Task TryGetDecimal_WithValidValue_ReturnsTrue()
+    {
+        // Arrange
+        var json = @"{""Value"": -98765.43}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Value"
+        await reader.ReadAsync(); // -98765.43
+        bool result = reader.TryGetDecimal(out decimal? value);
+
+        // Assert
+        result.Should().BeTrue();
+        value.Should().Be(-98765.43m);
+    }
+
+    #endregion
+
+    #region DateTime Methods
+
+    [Fact]
+    async Task GetDateTime_WithValidValue_ReturnsDateTime()
+    {
+        // Arrange
+        var json = $@"{{""Value"": ""{testDateTime:O}""}}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Value"
+        await reader.ReadAsync(); // datetime
+
+        // Assert
+        reader.GetDateTime().Should().Be(testDateTime);
+    }
+
+    [Fact]
+    async Task GetDateTimeOffset_WithValidValue_ReturnsDateTimeOffset()
+    {
+        // Arrange
+        var json = $@"{{""Value"": ""{testDateTimeOffset:O}""}}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Value"
+        await reader.ReadAsync(); // datetimeoffset
+
+        // Assert
+        reader.GetDateTimeOffset().Should().Be(testDateTimeOffset);
+    }
+
+    #endregion
+
+    #region GUID Methods
+
+    [Fact]
+    async Task GetGuid_WithValidValue_ReturnsGuid()
+    {
+        // Arrange
+        var json = $@"{{""Value"": ""{testGuid:D}""}}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Value"
+        await reader.ReadAsync(); // guid
+
+        // Assert
+        reader.GetGuid().Should().Be(testGuid);
+    }
+
+    [Fact]
+    async Task TryGetGuid_WithValidValue_ReturnsTrue()
+    {
+        // Arrange
+        var json = $@"{{""Value"": ""{testGuid:D}""}}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Value"
+        await reader.ReadAsync(); // guid
+        bool result = reader.TryGetGuid(out Guid? value);
+
+        // Assert
+        result.Should().BeTrue();
+        value.Should().Be(testGuid);
+    }
+
+    #endregion
+
+    #region Base64 Methods
+
+    [Fact]
+    async Task GetBytesFromBase64_WithValidBase64_ReturnsBytes()
+    {
+        // Arrange
+        var base64String = Convert.ToBase64String(Encoding.UTF8.GetBytes("Hello"));
+        var json = $@"{{""Value"": ""{base64String}""}}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Value"
+        await reader.ReadAsync(); // base64 string
+
+        // Assert
+        byte[]? result = reader.GetBytesFromBase64();
+        Encoding.UTF8.GetString(result!).Should().Be("Hello");
+    }
+
+    [Fact]
+    async Task GetBytesFromBase64_WithInvalidBase64_ThrowsFormatException()
+    {
+        // Arrange
+        var json = @"{""Value"": ""!!!INVALID!!!""}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Value"
+        await reader.ReadAsync(); // invalid base64
+
+        // Assert
+        var action = () => reader.GetBytesFromBase64();
+        action.Should().Throw<FormatException>();
+    }
+
+    [Fact]
+    async Task TryGetBytesFromBase64_WithValidBase64_ReturnsTrue()
+    {
+        // Arrange
+        var base64String = Convert.ToBase64String(Encoding.UTF8.GetBytes("World"));
+        var json = $@"{{""Value"": ""{base64String}""}}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Value"
+        await reader.ReadAsync(); // base64 string
+        bool result = reader.TryGetBytesFromBase64(out byte[]? value);
+
+        // Assert
+        result.Should().BeTrue();
+        Encoding.UTF8.GetString(value!).Should().Be("World");
+    }
+
+    [Fact]
+    async Task TryGetBytesFromBase64_WithInvalidBase64_ReturnsFalse()
+    {
+        // Arrange
+        var json = @"{""Value"": ""@@@NOTBASE64@@@""}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Value"
+        await reader.ReadAsync(); // invalid base64
+        bool result = reader.TryGetBytesFromBase64(out byte[]? value);
+
+        // Assert
+        result.Should().BeFalse();
+        value.Should().BeNull();
+    }
+
+    #endregion
+
+    #region GetValue Methods
+
+    [Fact]
+    async Task GetValue_WithString_ReturnsString()
+    {
+        // Arrange
+        var json = @"{""Name"": ""Test""}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Name"
+        await reader.ReadAsync(); // "Test"
+
+        // Assert
+        reader.GetValue().Should().Be("Test");
+    }
+
+    [Fact]
+    async Task GetValue_WithNumber_ReturnsNumber()
+    {
+        // Arrange
+        var json = @"{""Count"": 42}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Count"
+        await reader.ReadAsync(); // 42
+
+        // Assert
+        reader.GetValue().Should().Be(42);
+    }
+
+    [Fact]
+    async Task GetValue_WithBoolean_ReturnsBoolean()
+    {
+        // Arrange
+        var json = @"{""Enabled"": true}";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var reader = new JsonReader(stream);
+
+        // Act
+        await reader.ReadAsync(); // {
+        await reader.ReadAsync(); // "Enabled"
+        await reader.ReadAsync(); // true
+
+        // Assert
+        reader.GetValue().Should().Be(true);
+    }
+
+    #endregion
+}

--- a/src/System.Text.Json.Stream/Helpers/Utf8JsonHelpers.cs
+++ b/src/System.Text.Json.Stream/Helpers/Utf8JsonHelpers.cs
@@ -56,20 +56,91 @@ public static class Utf8JsonHelpers
     /// <returns>Boolean value of <see cref="JsonTokenType"/>, or <see langword="null"/> if the token is not a boolean.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool? GetBoolean(this Utf8JsonAsyncStreamReader reader)
-        => reader.TokenType == JsonTokenType.True ? true : reader.TokenType == JsonTokenType.False ? false : null;
+    {
+        return reader.TokenType switch
+        {
+            JsonTokenType.True => true,
+            JsonTokenType.False => false,
+            _ => null
+        };
+    }
 
     /// <summary>
     /// Get the string value from the reader.
     /// </summary>
     /// <param name="reader"><see cref="Utf8JsonAsyncStreamReader"/> instance.</param>
-    /// <returns>String value of <see cref="JsonTokenType"/></returns>
+    /// <returns>String value of <see cref="JsonTokenType"/>, or <see langword="null"/> if the token is <see cref="JsonTokenType.Null"/></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static string? GetString(this Utf8JsonAsyncStreamReader reader)
     {
-        if (reader.RawValueBytes is null) return null;
+        if (reader.TokenType == JsonTokenType.Null)
+        {
+            return null;
+        }
+
+        return reader.RawValueBytes is null ? null :
+            // Use _valueLength to get the correct substring, not the full array length
+            Encoding.UTF8.GetString(reader.RawValueBytes, 0, reader._valueLength);
+    }
+
+    /// <summary>
+    /// Copies the current JSON token value from the source, unescaped as a UTF-8 string to the destination buffer.
+    /// </summary>
+    /// <param name="reader"><see cref="Utf8JsonAsyncStreamReader"/> instance.</param>
+    /// <param name="utf8Destination">A buffer to write the unescaped UTF-8 bytes into.</param>
+    /// <returns>The number of bytes written to <paramref name="utf8Destination"/>.</returns>
+    /// <remarks>
+    /// This method will throw <see cref="ArgumentException"/> if the destination buffer is too small to hold the unescaped value.
+    /// An appropriately sized buffer can be determined by consulting the length of <see cref="Utf8JsonAsyncStreamReader.RawValueBytes"/>,
+    /// since the unescaped result is always less than or equal to the length of the encoded strings.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int CopyString(this Utf8JsonAsyncStreamReader reader, Span<byte> utf8Destination)
+    {
+        if (reader.RawValueBytes is null)
+        {
+            return 0;
+        }
+
+        ReadOnlySpan<byte> source = new(reader.RawValueBytes, 0, reader._valueLength);
         
-        // Use _valueLength to get the correct substring, not the full array length
-        return Encoding.UTF8.GetString(reader.RawValueBytes, 0, reader._valueLength);
+        if (source.Length > utf8Destination.Length)
+        {
+            throw new ArgumentException("The destination buffer is too small to hold the unescaped value.");
+        }
+
+        source.CopyTo(utf8Destination);
+        return source.Length;
+    }
+
+    /// <summary>
+    /// Copies the current JSON token value from the source, unescaped, and transcoded as a UTF-16 char buffer.
+    /// </summary>
+    /// <param name="reader"><see cref="Utf8JsonAsyncStreamReader"/> instance.</param>
+    /// <param name="destination">A buffer to write the transcoded UTF-16 characters into.</param>
+    /// <returns>The number of characters written to <paramref name="destination"/>.</returns>
+    /// <remarks>
+    /// This method will throw <see cref="ArgumentException"/> if the destination buffer is too small to hold the unescaped value.
+    /// An appropriately sized buffer can be determined by consulting the length of <see cref="Utf8JsonAsyncStreamReader.RawValueBytes"/>,
+    /// since the unescaped result is always less than or equal to the length of the encoded strings.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int CopyString(this Utf8JsonAsyncStreamReader reader, Span<char> destination)
+    {
+        string? str = reader.GetString();
+        
+        if (str is null)
+        {
+            return 0;
+        }
+
+        if (str.Length > destination.Length)
+        {
+            throw new ArgumentException("The destination buffer is too small to hold the unescaped value.");
+        }
+
+        str.AsSpan().CopyTo(destination);
+        return str.Length;
     }
 
     /// <summary>
@@ -90,8 +161,7 @@ public static class Utf8JsonHelpers
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool TryGetByte(this Utf8JsonAsyncStreamReader reader, out byte? value)
     {
-        if (reader.RawValueBytes != null && Utf8Parser.TryParse(reader.RawValueBytes, out byte tmp, out int bytesConsumed)
-                                         && reader._valueLength == bytesConsumed)
+        if (reader.RawValueBytes != null  && TryGetByteCore(out byte tmp, new ReadOnlySpan<byte>(reader.RawValueBytes, 0, reader._valueLength)))
         {
             value = tmp;
             return true;
@@ -102,13 +172,30 @@ public static class Utf8JsonHelpers
     }
 
     /// <summary>
+    /// Core method for parsing byte values from spans.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool TryGetByteCore(out byte value, ReadOnlySpan<byte> span)
+    {
+        if (Utf8Parser.TryParse(span, out byte tmp, out int bytesConsumed)
+            && span.Length == bytesConsumed)
+        {
+            value = tmp;
+            return true;
+        }
+
+        value = 0;
+        return false;
+    }
+
+    /// <summary>
     /// Get the unsigned byte value from the reader.
     /// </summary>
     /// <param name="reader"><see cref="Utf8JsonAsyncStreamReader"/> instance.</param>
     /// <returns>Unsigned byte value of <see cref="JsonTokenType"/></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static uint GetUByte(this Utf8JsonAsyncStreamReader reader)
-        => reader.TryGetUByte(out uint? value) ? value ?? default : default;
+        => reader.TryGetUByte(out uint? value) ? value ?? 0 : 0;
 
     /// <summary>
     /// Try getting the unsigned byte value from the reader.
@@ -119,14 +206,77 @@ public static class Utf8JsonHelpers
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool TryGetUByte(this Utf8JsonAsyncStreamReader reader, out uint? value)
     {
-        if (reader.RawValueBytes != null && Utf8Parser.TryParse(reader.RawValueBytes, out uint tmp, out int bytesConsumed)
-                                         && reader._valueLength == bytesConsumed)
+        if (reader.RawValueBytes != null 
+            && TryGetUByteCore(out uint tmp, new ReadOnlySpan<byte>(reader.RawValueBytes, 0, reader._valueLength)))
         {
             value = tmp;
             return true;
         }
 
         value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Core method for parsing unsigned byte values from spans.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool TryGetUByteCore(out uint value, ReadOnlySpan<byte> span)
+    {
+        if (Utf8Parser.TryParse(span, out uint tmp, out int bytesConsumed)
+            && span.Length == bytesConsumed)
+        {
+            value = tmp;
+            return true;
+        }
+
+        value = 0;
+        return false;
+    }
+
+    /// <summary>
+    /// Get the signed byte value from the reader.
+    /// </summary>
+    /// <param name="reader"><see cref="Utf8JsonAsyncStreamReader"/> instance.</param>
+    /// <returns>Signed byte value of <see cref="JsonTokenType"/></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static sbyte GetSByte(this Utf8JsonAsyncStreamReader reader)
+        => reader.TryGetSByte(out sbyte? value) ? value ?? 0 : default;
+
+    /// <summary>
+    /// Try getting the signed byte value from the reader.
+    /// </summary>
+    /// <param name="reader"><see cref="Utf8JsonAsyncStreamReader"/> instance.</param>
+    /// <param name="value">When the method returns, contains the value parsed from the reader, if the parsing operation succeeded.</param>
+    /// <returns><see langword="true" /> for success; <see langword="false" /> if the reader was not syntactically valid.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool TryGetSByte(this Utf8JsonAsyncStreamReader reader, out sbyte? value)
+    {
+        if (reader.RawValueBytes != null 
+            && TryGetSByteCore(out sbyte tmp, new ReadOnlySpan<byte>(reader.RawValueBytes, 0, reader._valueLength)))
+        {
+            value = tmp;
+            return true;
+        }
+
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Core method for parsing signed byte values from spans.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool TryGetSByteCore(out sbyte value, ReadOnlySpan<byte> span)
+    {
+        if (Utf8Parser.TryParse(span, out sbyte tmp, out int bytesConsumed)
+            && span.Length == bytesConsumed)
+        {
+            value = tmp;
+            return true;
+        }
+
+        value = 0;
         return false;
     }
 
@@ -148,14 +298,31 @@ public static class Utf8JsonHelpers
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool TryGetInt16(this Utf8JsonAsyncStreamReader reader, out short? value)
     {
-        if (reader.RawValueBytes != null && Utf8Parser.TryParse(reader.RawValueBytes, out short tmp, out int bytesConsumed)
-                                         && reader._valueLength == bytesConsumed)
+        if (reader.RawValueBytes != null 
+            && TryGetInt16Core(out short tmp, new ReadOnlySpan<byte>(reader.RawValueBytes, 0, reader._valueLength)))
         {
             value = tmp;
             return true;
         }
 
         value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Core method for parsing 16-bit integer values from spans.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool TryGetInt16Core(out short value, ReadOnlySpan<byte> span)
+    {
+        if (Utf8Parser.TryParse(span, out short tmp, out int bytesConsumed)
+            && span.Length == bytesConsumed)
+        {
+            value = tmp;
+            return true;
+        }
+
+        value = 0;
         return false;
     }
 
@@ -166,7 +333,7 @@ public static class Utf8JsonHelpers
     /// <returns>Unsigned 16-bit integer value of <see cref="JsonTokenType"/></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static uint GetUInt16(this Utf8JsonAsyncStreamReader reader)
-        => reader.TryGetUInt16(out uint? value) ? value ?? default : default;
+        => reader.TryGetUInt16(out uint? value) ? value ?? 0 : 0;
 
     /// <summary>
     /// Try getting the unsigned 16-bit integer value from the reader.
@@ -177,14 +344,31 @@ public static class Utf8JsonHelpers
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool TryGetUInt16(this Utf8JsonAsyncStreamReader reader, out uint? value)
     {
-        if (reader.RawValueBytes != null && Utf8Parser.TryParse(reader.RawValueBytes, out uint tmp, out int bytesConsumed)
-                                         && reader._valueLength == bytesConsumed)
+        if (reader.RawValueBytes != null 
+            && TryGetUInt16Core(out uint tmp, new ReadOnlySpan<byte>(reader.RawValueBytes, 0, reader._valueLength)))
         {
             value = tmp;
             return true;
         }
 
         value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Core method for parsing unsigned 16-bit integer values from spans.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool TryGetUInt16Core(out uint value, ReadOnlySpan<byte> span)
+    {
+        if (Utf8Parser.TryParse(span, out ushort tmp, out int bytesConsumed)
+            && span.Length == bytesConsumed)
+        {
+            value = tmp;
+            return true;
+        }
+
+        value = 0;
         return false;
     }
 
@@ -195,7 +379,7 @@ public static class Utf8JsonHelpers
     /// <returns>32-bit integer value of <see cref="JsonTokenType"/></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int GetInt32(this Utf8JsonAsyncStreamReader reader)
-        => reader.TryGetInt32(out int? value) ? value ?? default : default;
+        => reader.TryGetInt32(out int? value) ? value ?? 0 : 0;
 
     /// <summary>
     /// Try getting the 32-bit integer value from the reader.
@@ -206,14 +390,31 @@ public static class Utf8JsonHelpers
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool TryGetInt32(this Utf8JsonAsyncStreamReader reader, out int? value)
     {
-        if (reader.RawValueBytes != null && Utf8Parser.TryParse(reader.RawValueBytes, out int tmp, out int bytesConsumed)
-                                         && reader._valueLength == bytesConsumed)
+        if (reader.RawValueBytes != null 
+            && TryGetInt32Core(out int tmp, new ReadOnlySpan<byte>(reader.RawValueBytes, 0, reader._valueLength)))
         {
             value = tmp;
             return true;
         }
 
         value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Core method for parsing 32-bit integer values from spans.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool TryGetInt32Core(out int value, ReadOnlySpan<byte> span)
+    {
+        if (Utf8Parser.TryParse(span, out int tmp, out int bytesConsumed)
+            && span.Length == bytesConsumed)
+        {
+            value = tmp;
+            return true;
+        }
+
+        value = 0;
         return false;
     }
 
@@ -224,7 +425,7 @@ public static class Utf8JsonHelpers
     /// <returns>Unsigned 32-bit integer value of <see cref="JsonTokenType"/></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static uint GetUInt32(this Utf8JsonAsyncStreamReader reader)
-        => reader.TryGetUInt32(out uint? value) ? value ?? default : default;
+        => reader.TryGetUInt32(out uint? value) ? value ?? 0 : 0;
 
     /// <summary>
     /// Try getting the unsigned 32-bit integer value from the reader.
@@ -235,14 +436,31 @@ public static class Utf8JsonHelpers
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool TryGetUInt32(this Utf8JsonAsyncStreamReader reader, out uint? value)
     {
-        if (reader.RawValueBytes != null && Utf8Parser.TryParse(reader.RawValueBytes, out uint tmp, out int bytesConsumed)
-                                         && reader._valueLength == bytesConsumed)
+        if (reader.RawValueBytes != null 
+            && TryGetUInt32Core(out uint tmp, new ReadOnlySpan<byte>(reader.RawValueBytes, 0, reader._valueLength)))
         {
             value = tmp;
             return true;
         }
 
         value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Core method for parsing unsigned 32-bit integer values from spans.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool TryGetUInt32Core(out uint value, ReadOnlySpan<byte> span)
+    {
+        if (Utf8Parser.TryParse(span, out uint tmp, out int bytesConsumed)
+            && span.Length == bytesConsumed)
+        {
+            value = tmp;
+            return true;
+        }
+
+        value = 0;
         return false;
     }
 
@@ -253,7 +471,7 @@ public static class Utf8JsonHelpers
     /// <returns>64-bit integer value of <see cref="JsonTokenType"/></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static long GetInt64(this Utf8JsonAsyncStreamReader reader)
-        => reader.TryGetInt64(out long? value) ? value ?? default : default;
+        => reader.TryGetInt64(out long? value) ? value ?? 0 : 0;
 
     /// <summary>
     /// Try getting the 64-bit integer value from the reader.
@@ -264,14 +482,31 @@ public static class Utf8JsonHelpers
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool TryGetInt64(this Utf8JsonAsyncStreamReader reader, out long? value)
     {
-        if (reader.RawValueBytes != null && Utf8Parser.TryParse(reader.RawValueBytes, out long tmp, out int bytesConsumed)
-                                         && reader._valueLength == bytesConsumed)
+        if (reader.RawValueBytes != null 
+            && TryGetInt64Core(out long tmp, new ReadOnlySpan<byte>(reader.RawValueBytes, 0, reader._valueLength)))
         {
             value = tmp;
             return true;
         }
 
         value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Core method for parsing 64-bit integer values from spans.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool TryGetInt64Core(out long value, ReadOnlySpan<byte> span)
+    {
+        if (Utf8Parser.TryParse(span, out long tmp, out int bytesConsumed)
+            && span.Length == bytesConsumed)
+        {
+            value = tmp;
+            return true;
+        }
+
+        value = 0;
         return false;
     }
 
@@ -282,7 +517,7 @@ public static class Utf8JsonHelpers
     /// <returns>Unsigned 64-bit integer value of <see cref="JsonTokenType"/></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ulong GetUInt64(this Utf8JsonAsyncStreamReader reader)
-        => reader.TryGetUInt64(out ulong? value) ? value ?? default : default;
+        => reader.TryGetUInt64(out ulong? value) ? value ?? 0 : 0;
 
     /// <summary>
     /// Try getting the 64-bit unsigned integer value from the reader.
@@ -293,8 +528,8 @@ public static class Utf8JsonHelpers
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool TryGetUInt64(this Utf8JsonAsyncStreamReader reader, out ulong? value)
     {
-        if (reader.RawValueBytes != null && Utf8Parser.TryParse(reader.RawValueBytes, out ulong tmp, out int bytesConsumed)
-                                         && reader._valueLength == bytesConsumed)
+        if (reader.RawValueBytes != null 
+            && TryGetUInt64Core(out ulong tmp, new ReadOnlySpan<byte>(reader.RawValueBytes, 0, reader._valueLength)))
         {
             value = tmp;
             return true;
@@ -305,13 +540,30 @@ public static class Utf8JsonHelpers
     }
 
     /// <summary>
+    /// Core method for parsing unsigned 64-bit integer values from spans.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool TryGetUInt64Core(out ulong value, ReadOnlySpan<byte> span)
+    {
+        if (Utf8Parser.TryParse(span, out ulong tmp, out int bytesConsumed)
+            && span.Length == bytesConsumed)
+        {
+            value = tmp;
+            return true;
+        }
+
+        value = 0;
+        return false;
+    }
+
+    /// <summary>
     /// Get the single-precision floating-point number from the reader.
     /// </summary>
     /// <param name="reader"><see cref="Utf8JsonAsyncStreamReader"/> instance.</param>
     /// <returns>Single-precision floating-point number value of <see cref="JsonTokenType"/></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static float GetSingle(this Utf8JsonAsyncStreamReader reader)
-        => reader.TryGetSingle(out float? value) ? value ?? default : default;
+        => reader.TryGetSingle(out float? value) ? value ?? 0 : 0;
 
     /// <summary>
     /// Try getting the single-precision floating-point number value from the reader.
@@ -322,8 +574,9 @@ public static class Utf8JsonHelpers
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool TryGetSingle(this Utf8JsonAsyncStreamReader reader, out float? value)
     {
-        if (reader.RawValueBytes != null && Utf8Parser.TryParse(reader.RawValueBytes, out float tmp, out int bytesConsumed)
-                                         && reader._valueLength == bytesConsumed)
+        if (reader.RawValueBytes != null 
+            && Utf8Parser.TryParse(new ReadOnlySpan<byte>(reader.RawValueBytes, 0, reader._valueLength), out float tmp, out int bytesConsumed)
+            && reader._valueLength == bytesConsumed)
         {
             value = tmp;
             return true;
@@ -340,7 +593,7 @@ public static class Utf8JsonHelpers
     /// <returns>Double-precision floating-point number value of <see cref="JsonTokenType"/></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static double GetDouble(this Utf8JsonAsyncStreamReader reader)
-        => reader.TryGetDouble(out double? value) ? value ?? default : default;
+        => reader.TryGetDouble(out double? value) ? value ?? 0 : 0;
 
     /// <summary>
     /// Try getting the double-precision floating-point number from the reader.
@@ -351,8 +604,9 @@ public static class Utf8JsonHelpers
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool TryGetDouble(this Utf8JsonAsyncStreamReader reader, out double? value)
     {
-        if (reader.RawValueBytes != null && Utf8Parser.TryParse(reader.RawValueBytes, out double tmp, out int bytesConsumed)
-                                         && reader._valueLength == bytesConsumed)
+        if (reader.RawValueBytes != null 
+            && Utf8Parser.TryParse(new ReadOnlySpan<byte>(reader.RawValueBytes, 0, reader._valueLength), out double tmp, out int bytesConsumed)
+            && reader._valueLength == bytesConsumed)
         {
             value = tmp;
             return true;
@@ -369,7 +623,7 @@ public static class Utf8JsonHelpers
     /// <returns><see cref="T:System.Decimal" /> value of <see cref="JsonTokenType"/></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Decimal GetDecimal(this Utf8JsonAsyncStreamReader reader)
-        => reader.TryGetDecimal(out decimal? value) ? value ?? default : default;
+        => reader.TryGetDecimal(out decimal? value) ? value ?? 0 : 0;
 
     /// <summary>
     /// Try getting the <see cref="T:System.Decimal" /> value from the reader.
@@ -380,14 +634,31 @@ public static class Utf8JsonHelpers
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool TryGetDecimal(this Utf8JsonAsyncStreamReader reader, out decimal? value)
     {
-        if (reader.RawValueBytes != null && Utf8Parser.TryParse(reader.RawValueBytes, out decimal tmp, out int bytesConsumed)
-                                         && reader._valueLength == bytesConsumed)
+        if (reader.RawValueBytes != null 
+            && TryGetDecimalCore(out decimal tmp, new ReadOnlySpan<byte>(reader.RawValueBytes, 0, reader._valueLength)))
         {
             value = tmp;
             return true;
         }
 
         value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Core method for parsing decimal values from spans.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool TryGetDecimalCore(out decimal value, ReadOnlySpan<byte> span)
+    {
+        if (Utf8Parser.TryParse(span, out decimal tmp, out int bytesConsumed)
+            && span.Length == bytesConsumed)
+        {
+            value = tmp;
+            return true;
+        }
+
+        value = 0;
         return false;
     }
 
@@ -409,7 +680,8 @@ public static class Utf8JsonHelpers
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool TryGetDateTime(this Utf8JsonAsyncStreamReader reader, out DateTime? value)
     {
-        if (reader.RawValueBytes != null && DateTime.TryParse(reader.GetString(), out DateTime tmp))
+        string? str = reader.GetString();
+        if (str != null && DateTime.TryParse(str, out DateTime tmp))
         {
             value = tmp;
             return true;
@@ -437,7 +709,8 @@ public static class Utf8JsonHelpers
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool TryGetDateTimeOffset(this Utf8JsonAsyncStreamReader reader, out DateTimeOffset? value)
     {
-        if (reader.RawValueBytes != null && DateTimeOffset.TryParse(reader.GetString(), out DateTimeOffset tmp))
+        string? str = reader.GetString();
+        if (str != null && DateTimeOffset.TryParse(str, out DateTimeOffset tmp))
         {
             value = tmp;
             return true;
@@ -448,13 +721,66 @@ public static class Utf8JsonHelpers
     }
 
     /// <summary>
+    /// Parses the current JSON token value from the source and decodes the Base64 encoded JSON string as bytes.
+    /// </summary>
+    /// <param name="reader"><see cref="Utf8JsonAsyncStreamReader"/> instance.</param>
+    /// <returns>The decoded bytes from the Base64 encoded string.</returns>
+    /// <exception cref="FormatException">
+    /// The JSON string contains data outside the expected Base64 range, or if it contains invalid/more than two padding characters,
+    /// or is incomplete (i.e. the JSON string length is not a multiple of 4).
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static byte[]? GetBytesFromBase64(this Utf8JsonAsyncStreamReader reader)
+    {
+        if (!reader.TryGetBytesFromBase64(out byte[]? value))
+        {
+            throw new FormatException("The input is not a valid Base64 string.");
+        }
+        return value;
+    }
+
+    /// <summary>
+    /// Tries to parse the current JSON token value as a Base64 encoded string and decode it to bytes.
+    /// </summary>
+    /// <param name="reader"><see cref="Utf8JsonAsyncStreamReader"/> instance.</param>
+    /// <param name="value">When the method returns, contains the decoded bytes if successful.</param>
+    /// <returns><see langword="true" /> if the value was successfully decoded; <see langword="false" /> otherwise.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool TryGetBytesFromBase64(this Utf8JsonAsyncStreamReader reader, out byte[]? value)
+    {
+        if (reader.RawValueBytes is null)
+        {
+            value = null;
+            return false;
+        }
+
+        try
+        {
+            string? str = reader.GetString();
+            if (str is null)
+            {
+                value = null;
+                return false;
+            }
+
+            value = Convert.FromBase64String(str);
+            return true;
+        }
+        catch
+        {
+            value = null;
+            return false;
+        }
+    }
+
+    /// <summary>
     /// Get the <see cref="T:System.Guid" /> value from the reader.
     /// </summary>
     /// <param name="reader"><see cref="Utf8JsonAsyncStreamReader"/> instance.</param>
     /// <returns><see cref="T:System.Guid" /> value of <see cref="JsonTokenType"/></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Guid GetGuid(this Utf8JsonAsyncStreamReader reader)
-        => reader.TryGetGuid(out Guid? value) ? value ?? default : default;
+        => reader.TryGetGuid(out Guid? value) ? value ?? Guid.Empty : Guid.Empty;
 
     /// <summary>
     /// Try getting the <see cref="T:System.Guid" /> value from the reader.
@@ -465,14 +791,31 @@ public static class Utf8JsonHelpers
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool TryGetGuid(this Utf8JsonAsyncStreamReader reader, out Guid? value)
     {
-        if (reader.RawValueBytes != null && Utf8Parser.TryParse(reader.RawValueBytes, out Guid tmp, out int bytesConsumed)
-                                         && reader._valueLength == bytesConsumed)
+        if (reader.RawValueBytes != null 
+            && TryGetGuidCore(out Guid tmp, new ReadOnlySpan<byte>(reader.RawValueBytes, 0, reader._valueLength)))
         {
             value = tmp;
             return true;
         }
 
         value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Core method for parsing Guid values from spans.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool TryGetGuidCore(out Guid value, ReadOnlySpan<byte> span)
+    {
+        if (Utf8Parser.TryParse(span, out Guid tmp, out int bytesConsumed)
+            && span.Length == bytesConsumed)
+        {
+            value = tmp;
+            return true;
+        }
+
+        value = Guid.Empty;
         return false;
     }
 }

--- a/src/System.Text.Json.Stream/System.Text.Json.Stream.csproj
+++ b/src/System.Text.Json.Stream/System.Text.Json.Stream.csproj
@@ -14,10 +14,10 @@
     <RepositoryUrl>https://github.com/gragra33/Utf8JsonAsyncStreamReader</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Json, stream, streaming</PackageTags>
-    <PackageReleaseNotes>v2.0.0 - Added .NET 10.0 support; Dropped .NET 7.0 support (EOL); Multi-targeting for .NET 8.0, 9.0, and 10.0</PackageReleaseNotes>
-    <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <FileVersion>2.0.0.0</FileVersion>
-    <Version>2.0.0</Version>
+    <PackageReleaseNotes>v2.1.0 - Added .NET 10.0 support; Dropped .NET 7.0 support (EOL); Multi-targeting for .NET 8.0, 9.0, and 10.0</PackageReleaseNotes>
+    <AssemblyVersion>2.1.0.0</AssemblyVersion>
+    <FileVersion>2.1.0.0</FileVersion>
+    <Version>2.1.0</Version>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>


### PR DESCRIPTION
- Added new Value methods: CopyString (performant UTF8 & UTF16), GetSByte, TryGetSByte, GetBytesFromBase64, TryGetBytesFromBase64
- Updated readme with tables of all Value converter methods
- Added test coverage for new Value methods
